### PR TITLE
<feat> : <appBar & TabBAr 추가 >

### DIFF
--- a/lib/friends_page.dart
+++ b/lib/friends_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class FriendsPage extends StatefulWidget {
+  const FriendsPage({Key? key}) : super(key: key);
+
+  @override
+  State<FriendsPage> createState() => _FriendsPageState();
+}
+
+class _FriendsPageState extends State<FriendsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:vivino_demo/friends_page.dart';
+import 'package:vivino_demo/myprofile_page.dart';
+import 'package:vivino_demo/top_list_page.dart';
+import 'style/standardStyle.dart' as standardStyle;
+
+import './search_page.dart';
+
+void main() {
+  runApp(MaterialApp(
+      theme: standardStyle.them,
+      home:homePage(),
+  )
+  );
+}
+
+class homePage extends StatelessWidget {
+  const homePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return  MaterialApp(
+      theme: standardStyle.them,
+      home: DefaultTabController(
+        length: 4,
+        child: Scaffold(
+          appBar: AppBar(
+            actions: [
+              IconButton(
+                icon: Icon(Icons.notifications),
+                onPressed: (){},
+              ),
+              IconButton(
+                icon: Icon(Icons.add_box_outlined),
+                onPressed: (){},
+              ),
+            ],
+            bottom: const TabBar(
+              tabs: [
+                Tab(
+                  icon: Icon(Icons.flash_on),
+                ),
+                Tab(
+                  icon: Icon(Icons.sync),
+                ),
+                Tab(
+                  icon: Icon(Icons.storage),
+                ),
+                Tab(
+                  icon: Icon(Icons.present_to_all_outlined),
+
+                ),
+              ],
+            ),
+            title: const Text('Example'),
+          ),
+          body: const TabBarView(
+            children: [
+              TopListPage(),
+              SearchPage(),
+              FriendsPage(),
+              MyPrpfilePage()
+
+
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/myprofile_page.dart
+++ b/lib/myprofile_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class MyPrpfilePage extends StatefulWidget {
+  const MyPrpfilePage({Key? key}) : super(key: key);
+
+  @override
+  State<MyPrpfilePage> createState() => _MyPrpfilePageState();
+}
+
+class _MyPrpfilePageState extends State<MyPrpfilePage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/search_page.dart
+++ b/lib/search_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+
+class SearchPage extends StatefulWidget {
+  const SearchPage({Key? key}) : super(key: key);
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/top_list_page.dart
+++ b/lib/top_list_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TopListPage extends StatelessWidget {
+  const TopListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}


### PR DESCRIPTION
1. 앱에서 고정으로 사용할 상단 AppBar를 만들었습니다. 아직은 기능을 넣지않고 UI만 구성을 했습니다.
2. TabBar를 구현해서 4개의 페이지를 이동할 수 있는 기능을 구현했습니다. 아직 각 페이지마다는 특현 기능은 없습니다. 지금 이동만 할 수 있게 만들었습니다.
3. AppBar 좌측 상단에는 지금 페이지가 무엇인지 페이지의 이름을 알려주는 기능을 구현할 것입니다. 지금은 'Example'로 만 나옵니다.

   AppBar의 파라미터인 title에 페이지 이름을 알려주는 기능하는 widget 을 넣겠습니다 ` title: const Text('Example') `