### PR TITLE
<feat> : <add a  DetailSearch Page on search_page.dart >

### DIFF
--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -72,10 +72,48 @@ class _SearchBarState extends State<SearchBar> {
 }
 
 class DetailSearchPage extends StatelessWidget {
-  const DetailSearchPage({super.key});
+  DetailSearchPage({super.key});
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+        appBar: AppBar(
+      title: Container(
+        // Add padding around the search bar
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        // Use a Material design search bar
+        child: TextField(
+          cursorColor: Colors.black,
+          controller: _searchController,
+          decoration: InputDecoration(
+            filled: true,
+            fillColor: Colors.white,
+            hintText: 'Search...',
+            // Add a clear button to the search bar
+            suffixIcon: IconButton(
+              icon: Icon(
+                Icons.clear,
+                color: Colors.black,
+              ),
+              onPressed: () => _searchController.clear(),
+            ),
+            // Add a search icon or button to the search bar
+            prefixIcon: IconButton(
+              icon: Icon(
+                Icons.search,
+                color: Colors.black,
+              ),
+              onPressed: () {
+                // Perform the search here
+              },
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20.0),
+            ),
+          ),
+        ),
+      ),
+    ));
   }
 }

--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -41,6 +41,11 @@ class _SearchBarState extends State<SearchBar> {
         padding: const EdgeInsets.symmetric(horizontal: 8.0),
         // Use a Material design search bar
         child: TextField(
+          onTap: () {
+            Navigator.push(context, MaterialPageRoute(builder: (c) {
+              return DetailSearchPage();
+            }));
+          },
           controller: _searchController,
           decoration: InputDecoration(
             hintText: 'Search any wine',
@@ -63,5 +68,14 @@ class _SearchBarState extends State<SearchBar> {
         ),
       ),
     );
+  }
+}
+
+class DetailSearchPage extends StatelessWidget {
+  const DetailSearchPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
   }
 }


### PR DESCRIPTION
vivino 앱 search UI를 누르면 새로운 창이 덮어집니다. 그리고 그 창은
검색을 하기 좋은 환경을 제공을합니다. 네이버 앱에서 검색창을 누르면 검색
기록과 사용자가 검색을 할 내용을 예측하는 기능이 있는데 그것을
vivino 앱도 그러한 기능을 가지고 있습니다.

추가로 TabBar를 구현할 예정입니다.

<추가 사항>
 - Search UI를 구현
 - 뒤로가기 기능  appBar 왼쪽 상단에 구현
 - 현재 검색 단어 삭제 기능 구현