### PR TITLE
search_page.dart 수정 사항 

### DIFF
--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -72,10 +72,48 @@ class _SearchBarState extends State<SearchBar> {
 }
 
 class DetailSearchPage extends StatelessWidget {
-  const DetailSearchPage({super.key});
+  DetailSearchPage({super.key});
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+        appBar: AppBar(
+      title: Container(
+        // Add padding around the search bar
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        // Use a Material design search bar
+        child: TextField(
+          cursorColor: Colors.black,
+          controller: _searchController,
+          decoration: InputDecoration(
+            filled: true,
+            fillColor: Colors.white,
+            hintText: 'Search...',
+            // Add a clear button to the search bar
+            suffixIcon: IconButton(
+              icon: Icon(
+                Icons.clear,
+                color: Colors.black,
+              ),
+              onPressed: () => _searchController.clear(),
+            ),
+            // Add a search icon or button to the search bar
+            prefixIcon: IconButton(
+              icon: Icon(
+                Icons.search,
+                color: Colors.black,
+              ),
+              onPressed: () {
+                // Perform the search here
+              },
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20.0),
+            ),
+          ),
+        ),
+      ),
+    ));
   }
 }

--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -30,8 +30,38 @@ class SearchBar extends StatefulWidget {
 }
 
 class _SearchBarState extends State<SearchBar> {
+  final TextEditingController _searchController = TextEditingController();
+
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        // Add padding around the search bar
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        // Use a Material design search bar
+        child: TextField(
+          controller: _searchController,
+          decoration: InputDecoration(
+            hintText: 'Search any wine',
+            // Add a clear button to the search bar
+            suffixIcon: IconButton(
+              icon: Icon(Icons.clear),
+              onPressed: () => _searchController.clear(),
+            ),
+            // Add a search icon or button to the search bar
+            prefixIcon: IconButton(
+              icon: Icon(Icons.search),
+              onPressed: () {
+                // Perform the search here
+              },
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20.0),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -10,6 +10,26 @@ class SearchPage extends StatefulWidget {
 class _SearchPageState extends State<SearchPage> {
   @override
   Widget build(BuildContext context) {
+    return ListView.builder(
+        itemCount: 4,
+        itemBuilder: (BuildContext context, int index) {
+          if (index == 0) {
+            return SearchBar();
+          }
+        });
+  }
+}
+
+class SearchBar extends StatefulWidget {
+  const SearchBar({super.key});
+
+  @override
+  State<SearchBar> createState() => _SearchBarState();
+}
+
+class _SearchBarState extends State<SearchBar> {
+  @override
+  Widget build(BuildContext context) {
     return const Placeholder();
   }
 }

--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -15,6 +15,8 @@ class _SearchPageState extends State<SearchPage> {
         itemBuilder: (BuildContext context, int index) {
           if (index == 0) {
             return SearchBar();
+          } else {
+            return Container();
           }
         });
   }

--- a/lib/screens/search/search_page.dart
+++ b/lib/screens/search/search_page.dart
@@ -41,6 +41,11 @@ class _SearchBarState extends State<SearchBar> {
         padding: const EdgeInsets.symmetric(horizontal: 8.0),
         // Use a Material design search bar
         child: TextField(
+          onTap: () {
+            Navigator.push(context, MaterialPageRoute(builder: (c) {
+              return DetailSearchPage();
+            }));
+          },
           controller: _searchController,
           decoration: InputDecoration(
             hintText: 'Search any wine',
@@ -63,5 +68,14 @@ class _SearchBarState extends State<SearchBar> {
         ),
       ),
     );
+  }
+}
+
+class DetailSearchPage extends StatelessWidget {
+  const DetailSearchPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
   }
 }


### PR DESCRIPTION
search_page.dart에 있는 search UI 클릭시 상세하게 검색할 수 있는 페이지가 띄어집니다. (DetailSearchPage라는 위젯 실행)

DetailSearchPage는 검색하기에 알맞는 페이지를 조성할 것입니다. 아래 사진과 같이요
![KakaoTalk_20230516_151400679](https://github.com/earning-rightly/vivino_example-1.0/assets/109503403/10c6be59-9023-4c83-9bbe-ad64c2abeedd)

다음에는 tab을 만들어서 추가하겠습니다


